### PR TITLE
fixed syntax in config/database.py codeblock

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -29,7 +29,7 @@ DATABASES = {
     "database": "masonite",
     "user": "root",
     "password": "",
-    "port": 3306
+    "port": 3306,
     "prefix": "",
     "options": {
       #  
@@ -40,7 +40,7 @@ DATABASES = {
     "database": "masonite",
     "user": "root",
     "password": "",
-    "port": 5432
+    "port": 5432,
     "prefix": "",
     "options": {
       #  


### PR DESCRIPTION
This pull request fixes syntax mistakes in orm-documentation as mentioned in issue #3 