### PR TITLE
Fix docs to match code -- logging_queries in docs are incorrect -- should be log_queries

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -31,7 +31,7 @@ DATABASES = {
     "user": "root",
     "password": "",
     "port": 3306,
-    "logging_queries": False,
+    "log_queries": False,
     "options": {
       #  
     }
@@ -43,7 +43,7 @@ DATABASES = {
     "user": "root",
     "password": "",
     "port": 5432,
-    "logging_queries": False,
+    "log_queries": False,
     "options": {
       #  
     }
@@ -82,7 +82,7 @@ Masonite ORM supports Microsoft SQL Server and several options to modify the con
     "user": "root",
     "password": "",
     "port": 1433,
-    "logging_queries": False,
+    "log_queries": False,
     "options": {
       "trusted_connection": "Yes",
       "integrated_security": "sspi",
@@ -133,7 +133,7 @@ If there are any exceptions in inside the context then the transaction will be r
 ## Logging
 
 If you would like, you can log any queries Masonite ORM generates to any supported Python logging handler. First you need to enable logging
-in `config/database.py` file through the `logging_queries` boolean parameter.
+in `config/database.py` file through the `log_queries` boolean parameter.
 
 Inside your `config/database.py` file you can put on the bottom here. The StreamHandler will output the queries to the terminal.
 


### PR DESCRIPTION
based on the code in `masoniteorm/connections/BaseConnection.py` the key for logging queries is actually `log_queries`.  The documentation in `installation.md` refers to `logging_queries` instead.  This commit makes the documentation match.

One of the references in masonite-orm in connections/BaseConnection.py where I found the correct configuration key.

![Screen Shot 2021-08-18 at 7 13 47 PM](https://user-images.githubusercontent.com/987900/129997092-ed30e22b-a7e2-43f2-90aa-9585b4e1b763.png)